### PR TITLE
Fix parsing of time in Session and Window

### DIFF
--- a/src/variables/session/session.rs
+++ b/src/variables/session/session.rs
@@ -110,7 +110,7 @@ pub const SESSION_VARS_SEPARATOR: &str = ":";
 pub const SESSION_VARS: [(&str, u32, fn(s: &mut Session, p: &str)); SESSION_FLAGS_NUM] = [
     #[cfg(feature = "tmux_2_1")]
     ("session_activity", SESSION_ACTIVITY, |s, p| {
-        s.activity = p.parse().ok().map(Duration::from_millis)
+        s.activity = p.parse().ok().map(Duration::from_secs)
     }),
     #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
     (
@@ -132,7 +132,7 @@ pub const SESSION_VARS: [(&str, u32, fn(s: &mut Session, p: &str)); SESSION_FLAG
     }),
     #[cfg(feature = "tmux_1_6")]
     ("session_created", SESSION_CREATED, |s, p| {
-        s.created = p.parse().ok().map(Duration::from_millis)
+        s.created = p.parse().ok().map(Duration::from_secs)
     }),
     #[cfg(all(feature = "tmux_1_6", not(feature = "tmux_2_2")))]
     ("session_created_string", SESSION_CREATED_STRING, |s, p| {
@@ -186,7 +186,7 @@ pub const SESSION_VARS: [(&str, u32, fn(s: &mut Session, p: &str)); SESSION_FLAG
     ("session_id", SESSION_ID, |s, p| s.id = p[1..].parse().ok()), // skip '$' char
     #[cfg(feature = "tmux_2_1")]
     ("session_last_attached", SESSION_LAST_ATTACHED, |s, p| {
-        s.last_attached = p.parse().ok().map(Duration::from_millis)
+        s.last_attached = p.parse().ok().map(Duration::from_secs)
     }),
     #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
     (

--- a/src/variables/session/session_tests.rs
+++ b/src/variables/session/session_tests.rs
@@ -107,7 +107,7 @@ fn parse() {
     let session = Session::from_str(&session_str, SESSION_ALL).unwrap();
     let session_sample = Session {
         #[cfg(feature = "tmux_2_1")]
-        activity: Some(Duration::from_millis(1557947146)),
+        activity: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
         activity_string: None,
         #[cfg(feature = "tmux_2_1")]
@@ -117,7 +117,7 @@ fn parse() {
         #[cfg(feature = "tmux_3_1")]
         attached_list: None,
         #[cfg(feature = "tmux_1_6")]
-        created: Some(Duration::from_millis(1557947146)),
+        created: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_1_6", not(feature = "tmux_2_2")))]
         created_string: None,
         #[cfg(feature = "tmux_2_6")]
@@ -143,7 +143,7 @@ fn parse() {
         #[cfg(feature = "tmux_1_8")]
         id: Some(0),
         #[cfg(feature = "tmux_2_1")]
-        last_attached: Some(Duration::from_millis(1557947146)),
+        last_attached: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
         last_attached_string: None,
         #[cfg(feature = "tmux_2_0")]
@@ -177,7 +177,7 @@ fn parse2() {
     let session = Session::from_str(session_str, session_bitflag).unwrap();
     let origin = Session {
         #[cfg(feature = "tmux_2_1")]
-        activity: Some(Duration::from_millis(1557947146)),
+        activity: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
         activity_string: None,
         #[cfg(feature = "tmux_2_1")]
@@ -187,7 +187,7 @@ fn parse2() {
         #[cfg(feature = "tmux_3_1")]
         attached_list: None,
         #[cfg(feature = "tmux_1_6")]
-        created: Some(Duration::from_millis(1557947146)),
+        created: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_1_6", not(feature = "tmux_2_2")))]
         created_string: None,
         #[cfg(feature = "tmux_2_6")]
@@ -213,7 +213,7 @@ fn parse2() {
         #[cfg(feature = "tmux_1_8")]
         id: None,
         #[cfg(feature = "tmux_2_1")]
-        last_attached: Some(Duration::from_millis(1557947146)),
+        last_attached: Some(Duration::from_secs(1557947146)),
         #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
         last_attached_string: None,
         #[cfg(feature = "tmux_2_0")]

--- a/src/variables/window/window.rs
+++ b/src/variables/window/window.rs
@@ -156,7 +156,7 @@ pub const WINDOW_VARS: [(&str, u64, fn(w: &mut Window, p: &str)); WINDOW_FLAGS_N
     ),
     #[cfg(feature = "tmux_2_1")]
     ("window_activity", WINDOW_ACTIVITY, |w, p| {
-        w.activity = p.parse().ok().map(Duration::from_millis)
+        w.activity = p.parse().ok().map(Duration::from_secs)
     }),
     #[cfg(all(feature = "tmux_2_1", not(feature = "tmux_2_2")))]
     ("window_activity_string", WINDOW_ACTIVITY_STRING, |w, p| {


### PR DESCRIPTION
Fixes #5.

This is an API-breaking change, and therefore would probably require bumping the version to 0.2.