### PR TITLE
Retain binary arguments for new session command

### DIFF
--- a/src/commands/clients_and_sessions/new_session.rs
+++ b/src/commands/clients_and_sessions/new_session.rs
@@ -189,6 +189,7 @@ impl<'a> From<TmuxCommand<'a>> for NewSession<'a> {
     fn from(item: TmuxCommand<'a>) -> Self {
         Self(TmuxCommand {
             bin: item.bin,
+            bin_args: item.bin_args,
             cmd: Some(Cow::Borrowed(NEW_SESSION)),
             ..Default::default()
         })
@@ -199,6 +200,7 @@ impl<'a> From<&TmuxCommand<'a>> for NewSession<'a> {
     fn from(item: &TmuxCommand<'a>) -> Self {
         Self(TmuxCommand {
             bin: item.bin.clone(),
+            bin_args: item.bin_args.clone(),
             cmd: Some(Cow::Borrowed(NEW_SESSION)),
             ..Default::default()
         })

--- a/src/commands/clients_and_sessions/new_session_tests.rs
+++ b/src/commands/clients_and_sessions/new_session_tests.rs
@@ -137,3 +137,16 @@ fn new_session() {
     assert_eq!(new_session.0.cmd, Some(Cow::Borrowed(cmd)));
     assert_eq!(new_session.0.cmd_args, Some(s));
 }
+
+#[test]
+fn new_session_from_tmux_command() {
+    use crate::TmuxCommand;
+
+    let mut s = Vec::new();
+    s.extend_from_slice(&["-f", "myfile"]);
+    let s = s.into_iter().map(|a| a.into()).collect();
+
+    let cmd = TmuxCommand::new().file("myfile").new_session();
+
+    assert_eq!(cmd.0.bin_args, Some(s));
+}


### PR DESCRIPTION
When creating a `NewSession`-command from a `TmuxCommand` the binary arguments were not retained, causing snippets like 
```rust
TmuxCommand::new().file("abc").new_session();
```
to skip the `-f` option, making specifying a custom configuration file impossible.
This should fix it.