### PR TITLE
docs: Add `tmux_3_4` feature to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ under following conditions:
 
 - Tmux (covered tmux versions crate features):
     - [ ] master - `tmux_X_X`
+    - [x] 3.4 - `tmux_3_4`
     - [x] 3.3a - `tmux_3_3a`
     - [x] 3.3 - `tmux_3_3`
     - [x] 3.2a - `tmux_3_2a`


### PR DESCRIPTION
I noticed that tmux 3.4 support was added in version 0.3.2, this updates the README to list it (along with all of the other features / version combos).