### PR TITLE
feat: Add support for multiple keys in `send-keys` command

### DIFF
--- a/src/commands/key_bindings/send_keys.rs
+++ b/src/commands/key_bindings/send_keys.rs
@@ -104,7 +104,7 @@ pub struct SendKeys<'a> {
 
     /// `key`
     #[cfg(feature = "tmux_0_8")]
-    pub key: Option<Cow<'a, str>>,
+    pub keys: Vec<Cow<'a, str>>,
 }
 
 // FIXME: repeat-count
@@ -193,7 +193,7 @@ impl<'a> SendKeys<'a> {
     /// `key`
     #[cfg(feature = "tmux_0_8")]
     pub fn key<S: Into<Cow<'a, str>>>(mut self, key: S) -> Self {
-        self.key = Some(key.into());
+        self.keys.push(key.into());
         self
     }
 
@@ -270,7 +270,7 @@ impl<'a> SendKeys<'a> {
 
         // `key`
         #[cfg(feature = "tmux_0_8")]
-        if let Some(key) = self.key {
+        for key in self.keys {
             cmd.push_param(key);
         }
 

--- a/src/commands/key_bindings/send_keys_tests.rs
+++ b/src/commands/key_bindings/send_keys_tests.rs
@@ -80,7 +80,7 @@ fn send_keys() {
     #[cfg(all(feature = "tmux_0_8", not(feature = "tmux_1_6")))]
     let send_keys = send_keys.target_window(&target_pane);
     #[cfg(feature = "tmux_0_8")]
-    let send_keys = send_keys.key("3");
+    let send_keys = send_keys.key("3").key("4");
 
     #[cfg(not(feature = "cmd_alias"))]
     let cmd = "send-keys";
@@ -112,6 +112,7 @@ fn send_keys() {
     #[cfg(all(feature = "tmux_0_8", not(feature = "tmux_1_6")))]
     s.extend_from_slice(&["-t", "2"]);
     s.push("3");
+    s.push("4");
     let s: Vec<Cow<str>> = s.into_iter().map(|a| a.into()).collect();
 
     let send_keys = send_keys.build().to_vec();


### PR DESCRIPTION
## Description

This PR adds support for sending multiple keys in the `send-keys` command, allowing users to pass a sequence of keys as arguments. This enhancement improves the flexibility of keybinding and scripting within `tmux-interface-rs`.

## Example

```rust
use tmux_interface::SendKeys;

let sendkeys = SendKeys::new().key("cd ..").key("Enter");
```