### PR TITLE
Make invoker in ServerOptionsCtl the same as others

### DIFF
--- a/src/options/server/ctl/server_options_ctl.rs
+++ b/src/options/server/ctl/server_options_ctl.rs
@@ -76,16 +76,14 @@ impl<'a> ServerOptionsCtl<'a> {
     }
 
     pub fn get_all(&self) -> Result<ServerOptions<'a>, Error> {
-        let cmd = ShowOptions::new().server().build();
-        let output = (self.invoker)(cmd)?.to_string();
-        ServerOptions::from_str(&output)
+        Self::get_all_ext(self.invoker)
     }
 
     pub fn get_all_ext(
-        invoke: &dyn Fn(&mut TmuxCommand<'a>) -> String,
+        invoker: impl FnOnce(TmuxCommand<'a>) -> Result<TmuxOutput, Error>,
     ) -> Result<ServerOptions<'a>, Error> {
-        let mut cmd = ShowOptions::new().server().build();
-        let output = invoke(&mut cmd);
+        let cmd = ShowOptions::new().server().build();
+        let output = invoker(cmd)?.to_string();
         ServerOptions::from_str(&output)
     }
 


### PR DESCRIPTION
Found this while making #22, decided to split it off because this is definitely a source-breaking change to the API. Not sure why it was different from the others.