### PR TITLE
Streamline impl Display for TmuxOutput

### DIFF
--- a/src/commands/tmux_output.rs
+++ b/src/commands/tmux_output.rs
@@ -10,8 +10,8 @@ pub struct TmuxOutput(pub Output);
 impl fmt::Display for TmuxOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = &self.0.stdout.as_slice();
-        let output = String::from_utf8_lossy(s).to_string();
-        write!(f, "{}", output)
+        let output = String::from_utf8_lossy(s);
+        f.write_str(&output)
     }
 }
 


### PR DESCRIPTION
`String::from_utf8_lossy` returns a `Cow<str>` which can be dereferenced to a `&str` which is all that's needed for a `Formatter`. No need to force the construction of a `String` in the cases when the output is correct UTF-8.